### PR TITLE
Fixed invalid chars in path (folder)

### DIFF
--- a/lib/QuipProcessor.js
+++ b/lib/QuipProcessor.js
@@ -195,7 +195,7 @@ class QuipProcessor {
         this.logger.debug(`_processReference: replacement=${reference.replacement}, path=${path}`);
         return html.replace(reference.replacement, path);
     }
-    
+
     _renderDocumentHtml(html, title, path) {
         const pathDeepness = path.split("/").length-1;
 
@@ -217,7 +217,7 @@ class QuipProcessor {
 
         return html;
     }
-    
+
     async _getThreadMessagesHtml(quipThread, path) {
         let html = '';
         const pathDeepness = path.split("/").length-1;
@@ -320,12 +320,12 @@ class QuipProcessor {
     async _processDocumentThread(quipThread, path) {
         const pathDeepness = path.split("/").length-1;
         let threadHtml = quipThread.html;
-        
+
         //look up for images in html
         let matches = this._getMatchGroups(threadHtml,
             "src='(/blob/([\\w-]+)/([\\w-]+))'",
             ['replacement', 'threadId', 'blobId']);
-        
+
         //replace blob references for images
         for(const image of matches) {
             threadHtml = await this._processFile(threadHtml, image, path, this.options.embeddedImages);
@@ -423,7 +423,7 @@ class QuipProcessor {
     async _processFolders(quipFolders, path) {
         const promises = [];
         for(const index in quipFolders) {
-            promises.push(this._processFolder(quipFolders[index], `${path}${quipFolders[index].folder.title}/`));
+            promises.push(this._processFolder(quipFolders[index], `${path}${sanitizeFilename(quipFolders[index].folder.title)}/`));
         }
         await Promise.all(promises);
     }


### PR DESCRIPTION
Folder names in Quip were not being checked for invalid characters

As a result, the path variable could contain those invalid characters.
This PR calls sanitizeFilename on the folder so that as the path is 
being built, it will be valid.