### PR TITLE
Comments: Add a reference link back to the highlighted section

### DIFF
--- a/lib/QuipProcessor.js
+++ b/lib/QuipProcessor.js
@@ -295,8 +295,26 @@ class QuipProcessor {
                 dateStr = updatedDate === createdDate? createdDate : `${createdDate} (Updated: ${updatedDate})`;
                 dateStr = `, ${dateStr}`;
             }
+
+            let highlightedSections = "";
+            if (
+                message.annotation &&
+                message.annotation.id &&
+                message.annotation.highlight_section_ids
+            ) {
+                highlightedSections = message.annotation.highlight_section_ids.map((sectionId, index) => {
+                    // Not sure if there can be more than one highlight section,
+                    // but if so, we can number the reference links
+                    const suffix =
+                        message.annotation.highlight_section_ids.length == 1
+                        ? ""
+                        : ` ${index + 1}`;
+                    return `<a href="#${sectionId}">ref${suffix}</a>`;
+                })
+                .join(" ");
+            }
             if(text) {
-                html += `\n<div class="message"><span class="message--user">${message.author_name}${dateStr}<br/></span>${text}</div>`;
+                html += `\n<div class="message"><span class="message--user">${message.author_name}${dateStr} ${highlightedSections}<br/></span>${text}</div>`;
             }
         }
 

--- a/lib/QuipProcessor.js
+++ b/lib/QuipProcessor.js
@@ -298,14 +298,12 @@ class QuipProcessor {
 
             let referencedSections = "";
             if(message.annotation && message.annotation.id) {
-                if(message.annotation.highlight_section_ids) {
-                    referencedSections = message.annotation.highlight_section_ids.map((sectionId, index) => {
+                const uniqueSectionIds = [...new Set(message.annotation.highlight_section_ids)];
+                if(uniqueSectionIds.length > 0) {
+                    referencedSections = uniqueSectionIds.map((sectionId, index) => {
                         // Not sure if there can be more than one highlight section,
                         // but if so, we can number the reference links
-                        const suffix =
-                            message.annotation.highlight_section_ids.length == 1
-                            ? ""
-                            : ` ${index + 1}`;
+                        const suffix = uniqueSectionIds.length == 1 ? "" : ` ${index + 1}`;
                         return `<a href="#${sectionId}">ref${suffix}</a>`;
                     })
                     .join(" ");

--- a/lib/QuipProcessor.js
+++ b/lib/QuipProcessor.js
@@ -296,25 +296,26 @@ class QuipProcessor {
                 dateStr = `, ${dateStr}`;
             }
 
-            let highlightedSections = "";
-            if (
-                message.annotation &&
-                message.annotation.id &&
-                message.annotation.highlight_section_ids
-            ) {
-                highlightedSections = message.annotation.highlight_section_ids.map((sectionId, index) => {
-                    // Not sure if there can be more than one highlight section,
-                    // but if so, we can number the reference links
-                    const suffix =
-                        message.annotation.highlight_section_ids.length == 1
-                        ? ""
-                        : ` ${index + 1}`;
-                    return `<a href="#${sectionId}">ref${suffix}</a>`;
-                })
-                .join(" ");
+            let referencedSections = "";
+            if(message.annotation && message.annotation.id) {
+                if(message.annotation.highlight_section_ids) {
+                    referencedSections = message.annotation.highlight_section_ids.map((sectionId, index) => {
+                        // Not sure if there can be more than one highlight section,
+                        // but if so, we can number the reference links
+                        const suffix =
+                            message.annotation.highlight_section_ids.length == 1
+                            ? ""
+                            : ` ${index + 1}`;
+                        return `<a href="#${sectionId}">ref${suffix}</a>`;
+                    })
+                    .join(" ");
+                } else {
+                    // This is an annotation that doesn't highlight a full section
+                    referencedSections = `<a href="#${message.annotation.id}">ref</a>`;
+                }
             }
             if(text) {
-                html += `\n<div class="message"><span class="message--user">${message.author_name}${dateStr} ${highlightedSections}<br/></span>${text}</div>`;
+                html += `\n<div class="message"><span class="message--user">${message.author_name}${dateStr} ${referencedSections}<br/></span>${text}</div>`;
             }
         }
 

--- a/lib/templates/document.ejs
+++ b/lib/templates/document.ejs
@@ -29,6 +29,10 @@
         .message--user {
             font-weight: bold;
         }
+
+        :target {
+          background-color: yellow;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
The annotation comments/thread messages [include a reference to the object that they are annotating](https://quip.com/dev/automation/documentation/current#operation/getRecentMessages), so we can add a link to those comments to point back to that section or annotation. This may not always be applicable for all comments, but when it is available it helps with context. Otherwise it can be hard to decipher what a comment means without that context.

Note that if a comment refers to a deleted document section, there will still be a link that just doesn't go to anything. That seems fine for now.

This relates to #7 where the possibility of including annotation comments was previously discussed.

Screenshot of what it looks like:

![image](https://user-images.githubusercontent.com/47774/182733233-d08da4dc-5f32-4fb1-877a-6cbfdeda80a1.png)

https://gist.github.com/ibrahima/7fbe8b5f80baa6197406d960d2ab0f32

When you click on a ref link, it highlights the targetted section.