### PR TITLE
Handle rate limit 429

### DIFF
--- a/lib/QuipService.js
+++ b/lib/QuipService.js
@@ -1,14 +1,14 @@
 const fetch = require('node-fetch');
 const LoggerAdapter = require('./common/LoggerAdapter');
 
-const TIMES_LIMIT_503 = 10;
+const TIMES_LIMIT_429 = 10;
 
 class QuipService {
     constructor(accessToken, apiURL='https://platform.quip.com:443/1') {
         this.accessToken = accessToken;
         this.apiURL = apiURL;
         this.logger = new LoggerAdapter();
-        this.querries503 = new Map();
+        this.queries429 = new Map();
         this.waitingMs = 1000;
         this.stats = {
             query_count: 0,
@@ -109,20 +109,20 @@ class QuipService {
         try {
             const res = await fetch(`${this.apiURL}${url}`, this._getOptions(method));
             if(!res.ok) {
-                if(res.status === 503) {
+                if(res.status === 503 || res.status === 429) {
                     const currentTime = new Date().getTime();
                     const rateLimitReset = +res.headers.get('x-ratelimit-reset')*1000;
                     let waitingInMs = this.waitingMs;
                     if(rateLimitReset > currentTime) {
                         waitingInMs = rateLimitReset - currentTime;
                     }
-                    this.logger.debug(`HTTP 503: for ${url}, waiting in ms: ${waitingInMs}`);
-                    if(this._check503Query(url)) {
+                    this.logger.debug(`HTTP 429: for ${url}, waiting in ms: ${waitingInMs}`);
+                    if(this._check429Query(url)) {
                         return new Promise(resolve => setTimeout(() => {
                             resolve(this._apiCall(url, method, blob));
                         }, waitingInMs));
                     } else {
-                        this.logger.error(`Couldn't fetch ${url}, tryed to get it ${TIMES_LIMIT_503} times`);
+                        this.logger.error(`Couldn't fetch ${url}, tryed to get it ${TIMES_LIMIT_429} times`);
                         return;
                     }
                 } else {
@@ -141,14 +141,14 @@ class QuipService {
         }
     }
 
-    _check503Query(url) {
-        let count = this.querries503.get(url);
+    _check429Query(url) {
+        let count = this.queries429.get(url);
         if(!count) {
             count = 0;
         }
 
-        this.querries503.set(url, ++count);
-        if(count > TIMES_LIMIT_503) {
+        this.queries429.set(url, ++count);
+        if(count > TIMES_LIMIT_429) {
             return false;
         }
 

--- a/lib/__tests__/QuipService.test.js
+++ b/lib/__tests__/QuipService.test.js
@@ -31,9 +31,9 @@ function createResponse500() {
     return new Response("", {status: 500});
 }
 
-function createResponse503() {
+function createResponse429() {
     return new Response(JSON.stringify({waiting:waitingTime}), {
-        status: 503,
+        status: 429,
         headers: {'x-ratelimit-reset': waitingTime}
     });
 }
@@ -42,7 +42,7 @@ const quipService = new QuipService('###TOKEN###', 'http://quip.com');
 
 beforeEach(() => {
     quipService.stats.query_count = 0;
-    quipService.querries503 = new Map();
+    quipService.queries429 = new Map();
 });
 
 test('constructor tests', async () => {
@@ -51,16 +51,16 @@ test('constructor tests', async () => {
     expect(quipService.logger).toBeInstanceOf(LoggerAdapter);
 });
 
-test('_apiCall response with 503 code', async () => {
-    fetch.mockReturnValue(Promise.resolve(createResponse200())).mockReturnValueOnce(Promise.resolve(createResponse503()));
+test('_apiCall response with 429 code', async () => {
+    fetch.mockReturnValue(Promise.resolve(createResponse200())).mockReturnValueOnce(Promise.resolve(createResponse429()));
     const res = await quipService._apiCall('/someURL');
     expect(res.data).toBe(123456);
     expect(quipService.stats.query_count).toBe(2);
 });
 
-test('_apiCall response with 503 code more than 10 times', async () => {
+test('_apiCall response with 429 code more than 10 times', async () => {
     quipService.waitingMs = 50;
-    fetch.mockReturnValue(Promise.resolve(createResponse503()));
+    fetch.mockReturnValue(Promise.resolve(createResponse429()));
     const res = await quipService._apiCall('/someURL');
     expect(res).toBe(undefined);
     expect(quipService.logger.error).toHaveBeenCalledWith('Couldn\'t fetch /someURL, tryed to get it 10 times');


### PR DESCRIPTION
I observed that Quip returns 429 on rate limit exceeded. I failed to export my Quip docs several times but it worked after changing this line to handle both 429 and 503 the same way (though I don't think the API returns 503 for rate limits).

It should close https://github.com/sonnenkern/quip-export/issues/43