### PR TITLE
Add an optional parameter to set Api URL

### DIFF
--- a/app.js
+++ b/app.js
@@ -146,7 +146,8 @@ class App {
         }
 
         //Token verification
-        const quipService = new QuipService(this.cliArguments.token);
+        const quipService = new QuipService(this.cliArguments.token, this.cliArguments['api-url']);
+
         quipService.setLogger(this.Logger);
 
         if(!await quipService.checkUser()) {
@@ -161,14 +162,16 @@ class App {
             this.zip = new JSZip();
         }
 
-        this.quipProcessor = new QuipProcessor(this.cliArguments.token, this.fileSaver.bind(this), this.progressFunc.bind(this), this.phaseFunc.bind(this),
-            {
-                documentTemplate,
-                documentCSS: this.cliArguments['embedded-styles']? documentCSS : '',
-                embeddedImages: this.cliArguments['embedded-images'],
-                comments: this.cliArguments['comments'],
-                docx: this.cliArguments['docx']
-            });
+        let quipProcessorOptions = {
+            documentTemplate,
+            documentCSS: this.cliArguments['embedded-styles']? documentCSS : '',
+            embeddedImages: this.cliArguments['embedded-images'],
+            comments: this.cliArguments['comments'],
+            docx: this.cliArguments['docx'],
+            quipApiURL: this.cliArguments['api-url']
+        };
+
+        this.quipProcessor = new QuipProcessor(this.cliArguments.token, this.fileSaver.bind(this), this.progressFunc.bind(this), this.phaseFunc.bind(this), quipProcessorOptions);
 
         this.quipProcessor.setLogger(this.Logger);
 

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -59,6 +59,12 @@ module.exports =
     typeLabel: '{underline string}'
   },
   {
+    name: 'api-url',
+    type: String,
+    description: 'Quip API Url. Useful for self/company hosted Quip instances.',
+    typeLabel: '{underline string}'
+  },
+  {
     name: 'debug',
     type: Boolean,
     description: 'Debug mode'


### PR DESCRIPTION
In case of self (or company) hosted Quip instance, it might be useful to change the Quip API URL.
We can achieve this by simply adding a CLI option to supply the `api-url` parameter.